### PR TITLE
[common] add NormalizedValue

### DIFF
--- a/src/main/java/homer/common/normalization/NormalizedValue.java
+++ b/src/main/java/homer/common/normalization/NormalizedValue.java
@@ -1,0 +1,18 @@
+package homer.common.normalization;
+
+import homer.common.bounds.Bounds;
+
+/**
+ * Represents a normalized value.
+ */
+public interface NormalizedValue {
+
+    /**
+     * Rescales the value to a new scale.
+     * 
+     * @param newScale the new scale.
+     * @return the value rescaled to {@code newScale}.
+     */
+    double rescale(Bounds<Double> newScale);
+
+}

--- a/src/main/java/homer/common/normalization/NormalizedValueImpl.java
+++ b/src/main/java/homer/common/normalization/NormalizedValueImpl.java
@@ -1,0 +1,52 @@
+package homer.common.normalization;
+
+import java.util.Objects;
+
+import homer.common.bounds.Bounds;
+import homer.common.limit.Limit;
+
+/**
+ * Implementation of {@link NormalizedValue}.
+ */
+public final class NormalizedValueImpl implements NormalizedValue {
+
+    private final double value;
+    private final Bounds<Double> scale;
+
+    /**
+     * Constructs a {@code NormalizedValue}.
+     * 
+     * @param value the value.
+     * @param scale the scale of the {@code value}.
+     */
+    public NormalizedValueImpl(final double value, final Bounds<Double> scale) {
+        this.scale = Objects.requireNonNull(scale);
+        this.value = Limit.clamp(value, scale.getLowerBound(), scale.getUpperBound());
+    }
+
+    @Override
+    public double rescale(final Bounds<Double> newScale) {
+        return rescaleMinMax(this.value, this.scale, newScale);
+    }
+
+    /**
+     * Rescales a {@code value} in scale {@code oldScale} to {@code newScale}.
+     * 
+     * @param value    the value in the {@code oldScale}.
+     * @param oldScale the {@code value} scale.
+     * @param newScale the new scale.
+     * @return the {@code value} rescaled to {@code newScale}.
+     */
+    public static double rescaleMinMax(final double value, final Bounds<Double> oldScale,
+            final Bounds<Double> newScale) {
+        // https://en.wikipedia.org/wiki/Feature_scaling#Rescaling_(min-max_normalization)
+        // rescale a range between an arbitrary set of values [a, b]
+        final double a = newScale.getLowerBound();
+        final double b = newScale.getUpperBound();
+        final double minX = oldScale.getLowerBound();
+        final double maxX = oldScale.getUpperBound();
+        final double x = value;
+        return a + ((x - minX) * (b - a)) / (maxX - minX);
+    }
+
+}

--- a/src/test/java/homer/common/normalization/TestNormalizedValue.java
+++ b/src/test/java/homer/common/normalization/TestNormalizedValue.java
@@ -1,0 +1,32 @@
+package homer.common.normalization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import homer.common.bounds.Bounds;
+
+final class TestNormalizedValue {
+
+    private static final double NORMALIZED_BOTTOM = 0.0;
+    private static final double NORMALIZED_TOP = 100.0;
+    private static final double RESCALED_BOTTOM = 0.0;
+    private static final double RESCALED_TOP = 5000.0;
+    private static final Bounds<Double> NORMALIZED_SCALE = new Bounds<>(NORMALIZED_BOTTOM, NORMALIZED_TOP);
+    private static final Bounds<Double> NEW_SCALE = new Bounds<>(RESCALED_BOTTOM, RESCALED_TOP);
+
+    @Test
+    void testRescale() {
+        final var normalizedHalf = (NORMALIZED_SCALE.getLowerBound() + NORMALIZED_SCALE.getUpperBound()) / 2.0;
+        final var rescaledHalf = (NEW_SCALE.getLowerBound() + NEW_SCALE.getUpperBound()) / 2.0;
+
+        checkEquals(NORMALIZED_BOTTOM, RESCALED_BOTTOM);
+        checkEquals(NORMALIZED_TOP, RESCALED_TOP);
+        checkEquals(normalizedHalf, rescaledHalf);
+    }
+
+    private void checkEquals(final double normalized, final double rescaled) {
+        assertEquals(rescaled, new NormalizedValueImpl(normalized, NORMALIZED_SCALE).rescale(NEW_SCALE));
+        assertEquals(rescaled, NormalizedValueImpl.rescaleMinMax(normalized, NORMALIZED_SCALE, NEW_SCALE));
+    }
+}


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Normalization_(statistics)
https://en.wikipedia.org/wiki/Feature_scaling#Rescaling_(min-max_normalization)

If this is ok and merged we can edit/add the AdjustableDevice method and update the devices in an upstream branch.

Not sure how but it could be something like:

```java
void setNormalizedState(NormalizedValue normValue);
```
This will be added to AdjustableDevice or it will replace the setState (although not sure about replacing).

Possible implementation:

```java
void setNormalizedState(final NormalizedValue normValue) {
    this.state = normValue.rescale(this.bounds);
}
```

Alternatively instead of adding it into every device, it could be a proxy, but it would still need to be duplicated for the different types.