### PR TITLE
rename View to DeviceViewer

### DIFF
--- a/src/main/java/homer/controller/ViewManager.java
+++ b/src/main/java/homer/controller/ViewManager.java
@@ -1,24 +1,24 @@
 package homer.controller;
 
-import homer.view.View;
+import homer.view.DeviceViewer;
 
 /**
  * Manages all the views. Can be considered itself a view, since it supports all
  * view-related operations (since it will effectively dispatch them to the
  * actual views).
  */
-public interface ViewManager extends View {
+public interface ViewManager extends DeviceViewer {
 
     /**
      * 
      * @param view View to be added.
      */
-    void addView(View view);
+    void addView(DeviceViewer view);
 
     /**
      * 
      * @param view View to be removed.
      */
-    void removeView(View view);
+    void removeView(DeviceViewer view);
 
 }

--- a/src/main/java/homer/controller/ViewManagerImpl.java
+++ b/src/main/java/homer/controller/ViewManagerImpl.java
@@ -5,18 +5,18 @@ import java.util.List;
 
 import homer.api.DeviceId;
 import homer.api.DeviceState;
-import homer.view.View;
+import homer.view.DeviceViewer;
 
 public final class ViewManagerImpl implements ViewManager {
-    private final List<View> views = new ArrayList<>();
+    private final List<DeviceViewer> views = new ArrayList<>();
 
     @Override
-    public void addView(View view) {
+    public void addView(DeviceViewer view) {
         views.add(view);
     }
 
     @Override
-    public void removeView(View view) {
+    public void removeView(DeviceViewer view) {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'removeView'");
     }

--- a/src/main/java/homer/view/DeviceViewer.java
+++ b/src/main/java/homer/view/DeviceViewer.java
@@ -7,7 +7,7 @@ import homer.controller.Controller;
 /**
  * View that supports adding, removing and updating state of the devices.
  */
-public interface View {
+public interface DeviceViewer {
     /**
      * Updates the selected device's state on the view, and creates a new view if
      * it's not present yet.

--- a/src/main/java/homer/view/logger/Logger.java
+++ b/src/main/java/homer/view/logger/Logger.java
@@ -2,12 +2,12 @@ package homer.view.logger;
 
 import java.io.OutputStream;
 
-import homer.view.View;
+import homer.view.DeviceViewer;
 
 /**
  * Simple logger that logs to the selected output stream.
  */
-public interface Logger extends View {
+public interface Logger extends DeviceViewer {
 
     /**
      * Closes the old output stream and starts writing on the new one.


### PR DESCRIPTION
Seems like the 'View' name interferes with something else when you try to use the `ViewManager::addView()` method.
Also not every "view" is supposed to show the device states so it also makes sense for it not to be generic.

Another generic view interface should be made if we want to use the ViewManager to add other kind of views too, but care should be taken not to add functionalities which might not be shared.