### PR TITLE
[devicemanager] add method to get connected devices

### DIFF
--- a/src/main/java/homer/controller/DeviceManager.java
+++ b/src/main/java/homer/controller/DeviceManager.java
@@ -1,6 +1,10 @@
 package homer.controller;
 
+import java.util.Map;
+
 import homer.api.Device;
+import homer.api.DeviceId;
+import homer.controller.command.Command;
 
 /**
  * Manages devices and allows {@link Command}s to be
@@ -14,5 +18,12 @@ public interface DeviceManager extends DeviceManagerObserver {
      * @param device the device to be added.
      */
     void addDevice(Device<?> device);
+
+    /**
+     * Returns the currently connected devices.
+     * 
+     * @return the currently connected devices.
+     */
+    Map<DeviceId, Device<?>> getDevices();
 
 }

--- a/src/main/java/homer/controller/DeviceManagerImpl.java
+++ b/src/main/java/homer/controller/DeviceManagerImpl.java
@@ -76,4 +76,9 @@ public final class DeviceManagerImpl implements DeviceManager {
         }
     }
 
+    @Override
+    public Map<DeviceId, Device<?>> getDevices() {
+        return Map.copyOf(this.deviceMap);
+    }
+
 }


### PR DESCRIPTION
This is required somewhere (both for calling `updateTick` and for creating controller internal commands), not sure of the correct place (this should be it, since the view should only see `DeviceManagerObserver`? But it could be retrieved if the view uses the `Controller` interface).